### PR TITLE
K8S 1.22 compatibility

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Deploy kube-metrics-server on cluster
   local_action:
-    module: k8s
+    module: kubernetes.core.k8s
     state: "{{ kube_metrics_server_resource_state }}"
     kubeconfig: "{{ kube_metrics_server_kubeconfig }}"
     definition: "{{ lookup('template', item) }}"

--- a/templates/auth-delegator.yml.j2
+++ b/templates/auth-delegator.yml.j2
@@ -1,6 +1,6 @@
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: metrics-server:system:auth-delegator

--- a/templates/auth-reader.yml.j2
+++ b/templates/auth-reader.yml.j2
@@ -1,6 +1,6 @@
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-server-auth-reader

--- a/templates/metrics-apiservice.yml.j2
+++ b/templates/metrics-apiservice.yml.j2
@@ -1,6 +1,6 @@
 ---
 
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io

--- a/templates/metrics-server-deployment.yml.j2
+++ b/templates/metrics-server-deployment.yml.j2
@@ -1,5 +1,4 @@
 ---
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,6 +13,7 @@ metadata:
   labels:
     k8s-app: metrics-server
 spec:
+  replicas: 2
   selector:
     matchLabels:
       k8s-app: metrics-server
@@ -23,6 +23,16 @@ spec:
       labels:
         k8s-app: metrics-server
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: k8s-app
+                    operator: In
+                    values:
+                      - metrics-server
+              topologyKey: "kubernetes.io/hostname"
       serviceAccountName: metrics-server
       volumes:
       # mount in tmp so we can safely use from-scratch images and/or read-only containers
@@ -57,3 +67,9 @@ spec:
           readOnly: true
         - name: extension-apiserver-configmap-volume
           mountPath: /config
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi

--- a/templates/metrics-server-secret.yml.j2
+++ b/templates/metrics-server-secret.yml.j2
@@ -7,10 +7,10 @@ metadata:
 type: Opaque
 data:
   metrics-server.key: |
-{{ lookup('file', kube_metrics_server_keyfile) | b64encode | indent(4, indentfirst=True) }}
+{{ lookup('file', kube_metrics_server_keyfile) | b64encode | indent(4, first=True) }}
   metrics-server.cert: |
-{{ lookup('file', kube_metrics_server_certfile) | b64encode | indent(4, indentfirst=True) }}
+{{ lookup('file', kube_metrics_server_certfile) | b64encode | indent(4, first=True) }}
   kubelet-ca.cert: |
-{{ lookup('file', kube_metrics_server_kubelet_cafile) | b64encode | indent(4, indentfirst=True) }}
+{{ lookup('file', kube_metrics_server_kubelet_cafile) | b64encode | indent(4, first=True) }}
   requestheader-ca.cert: |
-{{ lookup('file', kube_metrics_server_requestheader_client_ca) | b64encode | indent(4, indentfirst=True) }}
+{{ lookup('file', kube_metrics_server_requestheader_client_ca) | b64encode | indent(4, first=True) }}


### PR DESCRIPTION
This PR fixes compatibility with newer Ansible versions (Jinja2 changes) and K8S 1.22+ (CRD version changes)
